### PR TITLE
Wayland and deps

### DIFF
--- a/devel/libepoll-shim/Makefile
+++ b/devel/libepoll-shim/Makefile
@@ -1,0 +1,33 @@
+#
+# libepoll-shim
+# https://github.com/jiixyj/epoll-shim
+#
+# Used by Wayland and libinput
+#
+
+PORTNAME= epoll-shim
+PORTVERSION= 0.1
+CATEGORIES=	devel
+
+MAINTAINER=	x11@FreeBSD.org
+
+USE_GITHUB=	yes
+GH_ACCOUNT=	jiixyj
+GH_PROJECT=	epoll-shim
+GH_TAGNAME=	b2de08a
+
+USE_LDCONFIG= yes
+
+do-install:
+	${MKDIR} ${STAGEDIR}${PREFIX}/include/sys
+	${INSTALL_DATA} ${WRKSRC}/include/sys/epoll.h ${STAGEDIR}${PREFIX}/include/sys/epoll.h
+	${INSTALL_DATA} ${WRKSRC}/include/sys/signalfd.h ${STAGEDIR}${PREFIX}/include/sys/signalfd.h
+	${INSTALL_DATA} ${WRKSRC}/include/sys/timerfd.h ${STAGEDIR}${PREFIX}/include/sys/timerfd.h
+	${INSTALL_LIB} ${WRKSRC}/libepoll-shim.a ${STAGEDIR}${PREFIX}/lib/
+	${INSTALL_LIB} ${WRKSRC}/libepoll-shim.so.0 ${STAGEDIR}${PREFIX}/lib/
+	${LN} -sf libepoll-shim.so.0 ${STAGEDIR}${PREFIX}/lib/libepoll-shim.so
+
+post-install:
+	${STRIP_CMD} ${STAGEDIR}${PREFIX}/lib/libepoll-shim.so.0
+
+.include <bsd.port.mk>

--- a/devel/libepoll-shim/distinfo
+++ b/devel/libepoll-shim/distinfo
@@ -1,0 +1,3 @@
+TIMESTAMP = 1471398672
+SHA256 (jiixyj-epoll-shim-0.1-b2de08a_GH0.tar.gz) = 21d83d65cf095809a8c23aea6684225fda4d1b86bd49db994f16961c0dc3e790
+SIZE (jiixyj-epoll-shim-0.1-b2de08a_GH0.tar.gz) = 7024

--- a/devel/libepoll-shim/files/patch-src_epoll.c
+++ b/devel/libepoll-shim/files/patch-src_epoll.c
@@ -1,0 +1,11 @@
+--- src/epoll.c.orig	2016-08-12 13:15:11 UTC
++++ src/epoll.c
+@@ -9,7 +9,7 @@
+ #include <poll.h>
+ #include <signal.h>
+ 
+-#if 0
++#if 1
+ int epoll_create(int size)
+ {
+ 	return epoll_create1(0);

--- a/devel/libepoll-shim/pkg-descr
+++ b/devel/libepoll-shim/pkg-descr
@@ -1,0 +1,6 @@
+#
+# libepoll-shim
+# https://github.com/jiixyj/epoll-shim
+#
+# Used by Wayland and libinput
+#

--- a/devel/libepoll-shim/pkg-plist
+++ b/devel/libepoll-shim/pkg-plist
@@ -1,0 +1,6 @@
+include/sys/epoll.h
+include/sys/signalfd.h
+include/sys/timerfd.h
+lib/libepoll-shim.a
+lib/libepoll-shim.so
+lib/libepoll-shim.so.0

--- a/graphics/wayland-protocols/Makefile
+++ b/graphics/wayland-protocols/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	wayland-protocols
-PORTVERSION=	1.3
+PORTVERSION=	1.6
 CATEGORIES=	graphics
 MASTER_SITES=	https://wayland.freedesktop.org/releases/
 

--- a/graphics/wayland-protocols/distinfo
+++ b/graphics/wayland-protocols/distinfo
@@ -1,2 +1,3 @@
-SHA256 (wayland-protocols-1.3.tar.xz) = 6bcd0633fdf9225ef1c7d2831f542e947f7d79811c79fc37f57b2e5375ded82f
-SIZE (wayland-protocols-1.3.tar.xz) = 101684
+TIMESTAMP = 1471412626
+SHA256 (wayland-protocols-1.6.tar.xz) = 9e4070bcaa38d38fa66bf055c6b5ad9c7c2553a78b2dbe5493fe0f3764d00e81
+SIZE (wayland-protocols-1.6.tar.xz) = 108676

--- a/graphics/wayland-protocols/pkg-plist
+++ b/graphics/wayland-protocols/pkg-plist
@@ -1,11 +1,15 @@
 libdata/pkgconfig/wayland-protocols.pc
 %%DATADIR%%/stable/presentation-time/presentation-time.xml
+%%DATADIR%%/stable/viewporter/viewporter.xml
 %%DATADIR%%/unstable/fullscreen-shell/fullscreen-shell-unstable-v1.xml
+%%DATADIR%%/unstable/idle-inhibit/idle-inhibit-unstable-v1.xml
 %%DATADIR%%/unstable/input-method/input-method-unstable-v1.xml
 %%DATADIR%%/unstable/linux-dmabuf/linux-dmabuf-unstable-v1.xml
 %%DATADIR%%/unstable/pointer-constraints/pointer-constraints-unstable-v1.xml
 %%DATADIR%%/unstable/pointer-gestures/pointer-gestures-unstable-v1.xml
 %%DATADIR%%/unstable/relative-pointer/relative-pointer-unstable-v1.xml
 %%DATADIR%%/unstable/tablet/tablet-unstable-v1.xml
+%%DATADIR%%/unstable/tablet/tablet-unstable-v2.xml
 %%DATADIR%%/unstable/text-input/text-input-unstable-v1.xml
+%%DATADIR%%/unstable/xdg-foreign/xdg-foreign-unstable-v1.xml
 %%DATADIR%%/unstable/xdg-shell/xdg-shell-unstable-v5.xml

--- a/graphics/wayland/Makefile
+++ b/graphics/wayland/Makefile
@@ -2,19 +2,18 @@
 # $FreeBSD$
 
 PORTNAME=	wayland
-PORTVERSION=	1.10.0
+PORTVERSION=	1.11.0
 CATEGORIES=	graphics
-MASTER_SITES=	http://rainbow-runner.nl/freebsd/
-#http://wayland.freedesktop.org/releases/
+MASTER_SITES= http://wayland.freedesktop.org/releases/
 
 MAINTAINER=	x11@FreeBSD.org
 COMMENT=	Wayland composite "server"
 
-LIB_DEPENDS=	libexpat.so:textproc/expat2 \
-		libffi.so:devel/libffi
-
+LIB_DEPENDS=	libexpat.so:${PORTSDIR}/textproc/expat2 \
+				libffi.so:${PORTSDIR}/devel/libffi \
+				libepoll-shim.so:${PORTSDIR}/devel/libepoll-shim
 WITH_DEBUG=	1
-USES=		gmake libtool pathfix pkgconfig tar:xz
+USES=		autoreconf gmake libtool pathfix pkgconfig tar:xz
 USE_GNOME=	libxslt:build
 USE_LDCONFIG=	yes
 GNU_CONFIGURE=	yes

--- a/graphics/wayland/distinfo
+++ b/graphics/wayland/distinfo
@@ -1,2 +1,3 @@
-SHA256 (wayland-1.10.0.tar.xz) = a25de240c2fe6e745ba4bada7c283364c8b13a2bfcf2db4907186f04f7b07a85
-SIZE (wayland-1.10.0.tar.xz) = 375992
+TIMESTAMP = 1471387009
+SHA256 (wayland-1.11.0.tar.xz) = 9540925f7928becfdf5e3b84c70757f6589bf1ceef09bea78784d8e4772c0db0
+SIZE (wayland-1.11.0.tar.xz) = 374468

--- a/graphics/wayland/files/patch-Makefile.am
+++ b/graphics/wayland/files/patch-Makefile.am
@@ -1,0 +1,29 @@
+--- Makefile.am.orig	2016-02-29 23:30:58 UTC
++++ Makefile.am
+@@ -73,7 +73,7 @@ nodist_include_HEADERS =			\
+ 	protocol/wayland-client-protocol.h
+ 
+ libwayland_server_la_CFLAGS = $(FFI_CFLAGS) $(AM_CFLAGS) -pthread
+-libwayland_server_la_LIBADD = $(FFI_LIBS) libwayland-private.la libwayland-util.la -lrt -lm
++libwayland_server_la_LIBADD = $(FFI_LIBS) $(EPOLLSHIM_LIBS) libwayland-private.la libwayland-util.la -lrt -lm
+ libwayland_server_la_LDFLAGS = -version-info 1:0:1
+ libwayland_server_la_SOURCES =			\
+ 	src/wayland-server.c			\
+@@ -85,7 +85,7 @@ nodist_libwayland_server_la_SOURCES =		\
+ 	protocol/wayland-protocol.c
+ 
+ libwayland_client_la_CFLAGS = $(FFI_CFLAGS) $(AM_CFLAGS) -pthread
+-libwayland_client_la_LIBADD = $(FFI_LIBS) libwayland-private.la libwayland-util.la -lrt -lm
++libwayland_client_la_LIBADD = $(FFI_LIBS) $(EPOLLSHIM_LIBS) libwayland-private.la libwayland-util.la -lrt -lm
+ libwayland_client_la_LDFLAGS = -version-info 3:0:3
+ libwayland_client_la_SOURCES =			\
+ 	src/wayland-client.c
+@@ -186,7 +186,7 @@ libtest_runner_la_LIBADD =			\
+ 	libwayland-util.la			\
+ 	libwayland-client.la			\
+ 	libwayland-server.la			\
+-	-lrt -ldl $(FFI_LIBS)
++	-lrt $(DL_LIBS) $(FFI_LIBS) $(EPOLLSHIM_LIBS)
+ 
+ 
+ array_test_SOURCES = tests/array-test.c

--- a/graphics/wayland/files/patch-configure.ac
+++ b/graphics/wayland/files/patch-configure.ac
@@ -1,0 +1,56 @@
+--- configure.ac.orig	2016-06-01 00:11:10 UTC
++++ configure.ac
+@@ -63,6 +63,28 @@ AC_SUBST(GCC_CFLAGS)
+ 
+ AC_CHECK_FUNCS([accept4 mkostemp posix_fallocate])
+ 
++AC_CHECK_HEADERS([sys/signalfd.h sys/timerfd.h])
++
++# Use epoll on Linux or kqueue on BSD
++AC_CHECK_HEADERS([sys/epoll.h sys/event.h])
++if test "x$ac_cv_header_sys_epoll_h" != "xyes" && test "x$ac_cv_header_sys_event_h" != "xyes"; then
++       AC_MSG_ERROR([Can't find sys/epoll.h or sys/event.h. Please ensure either epoll or kqueue is available.])
++fi
++
++# Credential support on FreeBSD
++AC_CHECK_HEADERS([sys/ucred.h])
++
++# dlopen()
++AC_CHECK_LIB([dl], [dlsym], [DL_LIBS=-ldl])
++AC_SUBST([DL_LIBS])
++
++# Defines __FreeBSD__ if we're on FreeBSD
++AC_CHECK_HEADERS([sys/param.h])
++
++# waitid() and signal.h are needed for the test suite.
++AC_CHECK_FUNCS([waitid])
++AC_CHECK_HEADERS([signal.h])
++
+ AC_ARG_ENABLE([libraries],
+ 	      [AC_HELP_STRING([--disable-libraries],
+ 			      [Disable compilation of wayland libraries])],
+@@ -98,11 +120,12 @@ AC_SUBST([ICONDIR])
+ 
+ if test "x$enable_libraries" = "xyes"; then
+ 	PKG_CHECK_MODULES(FFI, [libffi])
++dnl convert SFD_CLOEXEC and TFD_CLOEXEC to warning while figuring out how to do this.
+ 	AC_CHECK_DECL(SFD_CLOEXEC,[],
+-		      [AC_MSG_ERROR("SFD_CLOEXEC is needed to compile wayland libraries")],
++		      [AC_MSG_WARN("SFD_CLOEXEC is needed to compile wayland libraries")],
+ 		      [[#include <sys/signalfd.h>]])
+ 	AC_CHECK_DECL(TFD_CLOEXEC,[],
+-		      [AC_MSG_ERROR("TFD_CLOEXEC is needed to compile wayland libraries")],
++		      [AC_MSG_WARN("TFD_CLOEXEC is needed to compile wayland libraries")],
+ 		      [[#include <sys/timerfd.h>]])
+ 	AC_CHECK_DECL(CLOCK_MONOTONIC,[],
+ 		      [AC_MSG_ERROR("CLOCK_MONOTONIC is needed to compile wayland libraries")],
+@@ -110,6 +133,9 @@ if test "x$enable_libraries" = "xyes"; t
+ 	AC_CHECK_HEADERS([execinfo.h])
+ fi
+ 
++EPOLLSHIM_LIBS="-lepoll-shim"
++AC_SUBST(EPOLLSHIM_LIBS)
++
+ PKG_CHECK_MODULES(EXPAT, [expat], [],
+ 	[AC_CHECK_HEADERS(expat.h, [],
+ 		[AC_MSG_ERROR([Can't find expat.h. Please install expat.])])

--- a/graphics/wayland/files/patch-src_event-loop.c
+++ b/graphics/wayland/files/patch-src_event-loop.c
@@ -1,0 +1,590 @@
+--- src/event-loop.c.orig	2016-02-17 01:13:16 UTC
++++ src/event-loop.c
+@@ -23,6 +23,8 @@
+  * SOFTWARE.
+  */
+ 
++#include "../config.h"
++
+ #include <stddef.h>
+ #include <stdio.h>
+ #include <errno.h>
+@@ -32,16 +34,30 @@
+ #include <fcntl.h>
+ #include <sys/socket.h>
+ #include <sys/un.h>
++
++#ifdef HAVE_SYS_EPOLL_H
+ #include <sys/epoll.h>
++#ifdef HAVE_SYS_SIGNALFD_H
+ #include <sys/signalfd.h>
++#endif /* signalfd */
++#ifdef HAVE_SYS_TIMERFD_H
+ #include <sys/timerfd.h>
++#endif /* timerfd */
++#elif HAVE_SYS_EVENT_H
++#include <sys/types.h>
++#include <sys/event.h>
++#include <sys/time.h>
++#else /* !epoll && !kqueue */
++#error "Unsupported event system. Only epoll and kqueue are supported."
++#endif
++
+ #include <unistd.h>
+ #include "wayland-private.h"
+ #include "wayland-server.h"
+ #include "wayland-os.h"
+ 
+ struct wl_event_loop {
+-	int epoll_fd;
++	int event_fd;
+ 	struct wl_list check_list;
+ 	struct wl_list idle_list;
+ 	struct wl_list destroy_list;
+@@ -50,8 +66,13 @@ struct wl_event_loop {
+ };
+ 
+ struct wl_event_source_interface {
++#ifdef HAVE_SYS_EPOLL_H
+ 	int (*dispatch)(struct wl_event_source *source,
+ 			struct epoll_event *ep);
++#elif HAVE_SYS_EVENT_H
++	int (*dispatch)(struct wl_event_source *source,
++			struct kevent *ep);
++#endif
+ };
+ 
+ struct wl_event_source {
+@@ -68,6 +89,7 @@ struct wl_event_source_fd {
+ 	int fd;
+ };
+ 
++#ifdef HAVE_SYS_EPOLL_H
+ static int
+ wl_event_source_fd_dispatch(struct wl_event_source *source,
+ 			    struct epoll_event *ep)
+@@ -87,11 +109,33 @@ wl_event_source_fd_dispatch(struct wl_ev
+ 
+ 	return fd_source->func(fd_source->fd, mask, source->data);
+ }
++#elif HAVE_SYS_EVENT_H
++static int
++wl_event_source_fd_dispatch(struct wl_event_source *source,
++                           struct kevent *ev)
++{
++       struct wl_event_source_fd *fd_source =
++               (struct wl_event_source_fd *) source;
++       uint32_t mask;
++
++       mask = 0;
++       if (ev->filter == EVFILT_READ)
++               mask |= WL_EVENT_READABLE;
++       if (ev->filter == EVFILT_WRITE)
++               mask |= WL_EVENT_WRITABLE;
++       if (ev->flags & EV_ERROR)
++               mask |= WL_EVENT_ERROR;
++
++       return fd_source->func(fd_source->fd, mask, source->data);
++}
++#endif
++
+ 
+ struct wl_event_source_interface fd_source_interface = {
+ 	wl_event_source_fd_dispatch,
+ };
+ 
++#ifdef HAVE_SYS_EPOLL_H
+ static struct wl_event_source *
+ add_source(struct wl_event_loop *loop,
+ 	   struct wl_event_source *source, uint32_t mask, void *data)
+@@ -114,7 +158,7 @@ add_source(struct wl_event_loop *loop,
+ 		ep.events |= EPOLLOUT;
+ 	ep.data.ptr = source;
+ 
+-	if (epoll_ctl(loop->epoll_fd, EPOLL_CTL_ADD, source->fd, &ep) < 0) {
++	if (epoll_ctl(loop->event_fd, EPOLL_CTL_ADD, source->fd, &ep) < 0) {
+ 		close(source->fd);
+ 		free(source);
+ 		return NULL;
+@@ -122,6 +166,47 @@ add_source(struct wl_event_loop *loop,
+ 
+ 	return source;
+ }
++#elif HAVE_SYS_EVENT_H
++static struct wl_event_source *
++add_source(struct wl_event_loop *loop,
++	   struct wl_event_source *source, uint32_t mask, void *data)
++{
++	struct kevent events[2];
++       unsigned int num_events = 0;
++
++       if (source->fd < 0) {
++               fprintf(stderr, "could not add source\n: %m");
++               free(source);
++               return NULL;
++       }
++
++       source->loop = loop;
++       source->data = data;
++       wl_list_init(&source->link);
++
++       if (mask & WL_EVENT_READABLE) {
++               EV_SET(&events[num_events], source->fd, EVFILT_READ,
++                      EV_ADD | EV_ENABLE, 0, 0, source);
++               num_events++;
++       }
++
++       if (mask & WL_EVENT_WRITABLE) {
++               EV_SET(&events[num_events], source->fd, EVFILT_WRITE,
++                      EV_ADD | EV_ENABLE, 0, 0, source);
++               num_events++;
++       }
++
++       if (kevent(loop->event_fd, events, num_events, NULL, 0, NULL) < 0) {
++               fprintf(stderr, "error adding source %i (%p) to loop %p: %s\n",
++                       source->fd, source, loop, strerror(errno));
++               close(source->fd);
++               free(source);
++               return NULL;
++       }
++
++       return source;
++}
++#endif
+ 
+ WL_EXPORT struct wl_event_source *
+ wl_event_loop_add_fd(struct wl_event_loop *loop,
+@@ -143,6 +228,7 @@ wl_event_loop_add_fd(struct wl_event_loo
+ 	return add_source(loop, &source->base, mask, data);
+ }
+ 
++#ifdef HAVE_SYS_EPOLL_H
+ WL_EXPORT int
+ wl_event_source_fd_update(struct wl_event_source *source, uint32_t mask)
+ {
+@@ -156,27 +242,62 @@ wl_event_source_fd_update(struct wl_even
+ 		ep.events |= EPOLLOUT;
+ 	ep.data.ptr = source;
+ 
+-	return epoll_ctl(loop->epoll_fd, EPOLL_CTL_MOD, source->fd, &ep);
++	return epoll_ctl(loop->event_fd, EPOLL_CTL_MOD, source->fd, &ep);
++}
++#elif HAVE_SYS_EVENT_H
++WL_EXPORT int
++wl_event_source_fd_update(struct wl_event_source *source, uint32_t mask)
++{
++       struct wl_event_loop *loop = source->loop;
++       struct kevent events[2];
++       unsigned int num_events = 0;
++
++       if (mask & WL_EVENT_READABLE) {
++       EV_SET(&events[num_events], source->fd, EVFILT_READ,
++                      EV_ADD | EV_ENABLE, 0, 0, source);
++               num_events++;
++       }
++
++       if (mask & WL_EVENT_WRITABLE) {
++               EV_SET(&events[num_events], source->fd, EVFILT_WRITE,
++                      EV_ADD | EV_ENABLE, 0, 0, source);
++               num_events++;
++       }
++
++       return kevent(loop->event_fd, events, num_events, NULL, 0, NULL);
+ }
++#endif
+ 
+ struct wl_event_source_timer {
+ 	struct wl_event_source base;
+ 	wl_event_loop_timer_func_t func;
+ };
+ 
++#ifdef HAVE_SYS_EPOLL_H
+ static int
+ wl_event_source_timer_dispatch(struct wl_event_source *source,
+ 			       struct epoll_event *ep)
++#elif HAVE_SYS_EVENT_H
++static int
++wl_event_source_timer_dispatch(struct wl_event_source *source,
++                              struct kevent *ev)
++#endif
+ {
+ 	struct wl_event_source_timer *timer_source =
+ 		(struct wl_event_source_timer *) source;
+ 	uint64_t expires;
++#ifdef HAVE_SYS_TIMERFD_H
+ 	int len;
+ 
++	/* Linux. Read the number of missed expirations from the FD. */
+ 	len = read(source->fd, &expires, sizeof expires);
+ 	if (!(len == -1 && errno == EAGAIN) && len != sizeof expires)
+ 		/* Is there anything we can do here?  Will this ever happen? */
+ 		wl_log("timerfd read error: %m\n");
++#else
++	/* FreeBSD. Grab the number of missed expires from the kevent. */
++	expires = ev->data;
++#endif
+ 
+ 	return timer_source->func(timer_source->base.data);
+ }
+@@ -197,16 +318,29 @@ wl_event_loop_add_timer(struct wl_event_
+ 		return NULL;
+ 
+ 	source->base.interface = &timer_source_interface;
++	source->func = func;
++#ifdef HAVE_SYS_TIMERFD_H
+ 	source->base.fd = timerfd_create(CLOCK_MONOTONIC,
+ 					 TFD_CLOEXEC | TFD_NONBLOCK);
+-	source->func = func;
+ 
+ 	return add_source(loop, &source->base, WL_EVENT_READABLE, data);
++#else
++       /* FreeBSD. We use kqueue() timers directly.
++        * See: wl_event_source_timer_update(). */
++       source->base.fd = 0;
++       source->base.loop = loop;
++       source->base.data = data;
++       wl_list_init(&source->base.link);
++
++       return &source->base;
++#endif
+ }
+ 
+ WL_EXPORT int
+ wl_event_source_timer_update(struct wl_event_source *source, int ms_delay)
+ {
++#ifdef HAVE_SYS_TIMERFD_H
++	/* Linux */
+ 	struct itimerspec its;
+ 
+ 	its.it_interval.tv_sec = 0;
+@@ -217,6 +351,20 @@ wl_event_source_timer_update(struct wl_e
+ 		return -1;
+ 
+ 	return 0;
++#else
++        /* FreeBSD. */
++       struct kevent ev;
++
++       EV_SET(&ev, 0, EVFILT_TIMER, EV_ADD | EV_ENABLE | EV_ONESHOT, 0,
++              ms_delay, source);
++
++       if (kevent(source->loop->event_fd, &ev, 1, NULL, 0, NULL) < 0) {
++               fprintf(stderr, "could not set kqueue timer\n: %m");
++               return -1;
++       }
++
++       return 0;
++#endif
+ }
+ 
+ struct wl_event_source_signal {
+@@ -225,12 +373,19 @@ struct wl_event_source_signal {
+ 	wl_event_loop_signal_func_t func;
+ };
+ 
++#ifdef HAVE_SYS_EPOLL_H
+ static int
+ wl_event_source_signal_dispatch(struct wl_event_source *source,
+ 			       struct epoll_event *ep)
++#elif HAVE_SYS_EVENT_H
++static int
++wl_event_source_signal_dispatch(struct wl_event_source *source,
++                               struct kevent *ev)
++#endif
+ {
+ 	struct wl_event_source_signal *signal_source =
+ 		(struct wl_event_source_signal *) source;
++#ifdef HAVE_SYS_SIGNALFD_H
+ 	struct signalfd_siginfo signal_info;
+ 	int len;
+ 
+@@ -238,6 +393,7 @@ wl_event_source_signal_dispatch(struct w
+ 	if (!(len == -1 && errno == EAGAIN) && len != sizeof signal_info)
+ 		/* Is there anything we can do here?  Will this ever happen? */
+ 		wl_log("signalfd read error: %m\n");
++#endif
+ 
+ 	return signal_source->func(signal_source->signal_number,
+ 				   signal_source->base.data);
+@@ -255,6 +411,9 @@ wl_event_loop_add_signal(struct wl_event
+ {
+ 	struct wl_event_source_signal *source;
+ 	sigset_t mask;
++#ifndef HAVE_SYS_SIGNALFD_H
++       struct kevent ev;
++#endif
+ 
+ 	source = malloc(sizeof *source);
+ 	if (source == NULL)
+@@ -262,15 +421,37 @@ wl_event_loop_add_signal(struct wl_event
+ 
+ 	source->base.interface = &signal_source_interface;
+ 	source->signal_number = signal_number;
++	source->func = func;
+ 
++	/* Block delivery of signal_number to this process. */
+ 	sigemptyset(&mask);
+ 	sigaddset(&mask, signal_number);
+-	source->base.fd = signalfd(-1, &mask, SFD_CLOEXEC | SFD_NONBLOCK);
+ 	sigprocmask(SIG_BLOCK, &mask, NULL);
+ 
+-	source->func = func;
++#ifdef HAVE_SYS_SIGNALFD_H
++	/* Linux. Use signalfd. */
++	source->base.fd = signalfd(-1, &mask, SFD_CLOEXEC | SFD_NONBLOCK);
+ 
+ 	return add_source(loop, &source->base, WL_EVENT_READABLE, data);
++#else
++	/* FreeBSD. Use kqueue() signals directly. */
++       source->base.fd = 0;
++       source->base.loop = loop;
++       source->base.data = data;
++       wl_list_init(&source->base.link);
++
++       EV_SET(&ev, signal_number, EVFILT_SIGNAL, EV_ADD | EV_ENABLE, 0, 0,
++              source);
++
++       if (kevent(loop->event_fd, &ev, 1, NULL, 0, NULL) < 0) {
++               fprintf(stderr, "error adding signal for %i (%p), %p: %s\n",
++                       signal_number, source, loop, strerror(errno));
++		free(source);
++		return NULL;
++	}
++
++	return &source->base;
++#endif
+ }
+ 
+ struct wl_event_source_idle {
+@@ -311,6 +492,8 @@ wl_event_source_check(struct wl_event_so
+ 	wl_list_insert(source->loop->check_list.prev, &source->link);
+ }
+ 
++
++#ifdef HAVE_SYS_EPOLL_H
+ WL_EXPORT int
+ wl_event_source_remove(struct wl_event_source *source)
+ {
+@@ -319,7 +502,7 @@ wl_event_source_remove(struct wl_event_s
+ 	/* We need to explicitly remove the fd, since closing the fd
+ 	 * isn't enough in case we've dup'ed the fd. */
+ 	if (source->fd >= 0) {
+-		epoll_ctl(loop->epoll_fd, EPOLL_CTL_DEL, source->fd, NULL);
++		epoll_ctl(loop->event_fd, EPOLL_CTL_DEL, source->fd, NULL);
+ 		close(source->fd);
+ 		source->fd = -1;
+ 	}
+@@ -329,6 +512,82 @@ wl_event_source_remove(struct wl_event_s
+ 
+ 	return 0;
+ }
++#elif HAVE_SYS_EVENT_H
++WL_EXPORT int
++wl_event_source_remove(struct wl_event_source *source)
++{
++       struct wl_event_loop *loop = source->loop;
++       int ret = 0, saved_errno = 0;
++
++       /* Since FreeBSD doesn't treat all event sources as FDs, we need to
++        * differentiate by source interface. */
++       if (source->interface == &fd_source_interface && source->fd >= 0) {
++               struct kevent ev[2];
++               int _ret[2], _saved_errno[2];
++
++               /* We haven't stored state about the mask used when adding the
++                * source, so we have to try and remove both READ and WRITE
++                * filters. One may fail, which is OK. Removal of the source has
++                * only failed if _both_ kevent() calls fail. We have to do two
++                * kevent() calls so that we can get independent return values
++                * for the two kevents. */
++               EV_SET(&ev[0], source->fd, EVFILT_READ, EV_DELETE, 0, 0,
++                      source);
++               EV_SET(&ev[1], source->fd, EVFILT_WRITE, EV_DELETE, 0, 0,
++                      source);
++
++               _ret[0] = kevent(loop->event_fd, &ev[0], 1, NULL, 0, NULL);
++               _saved_errno[0] = errno;
++               _ret[1] = kevent(loop->event_fd, &ev[1], 1, NULL, 0, NULL);
++               _saved_errno[1] = errno;
++
++               if (_ret[0] >= _ret[1]) {
++                       ret = _ret[0];
++                       saved_errno = _saved_errno[0];
++               } else {
++                       ret = _ret[1];
++                       saved_errno = _saved_errno[1];
++               }
++
++               close(source->fd);
++       } else if (source->interface == &timer_source_interface) {
++               struct kevent ev;
++
++               /* Only one kevent() call needed. */
++               EV_SET(&ev, 0, EVFILT_TIMER, EV_DELETE, 0, 0, source);
++               ret = kevent(loop->event_fd, &ev, 1, NULL, 0, NULL);
++               saved_errno = errno;
++       } else if (source->interface == &signal_source_interface) {
++               struct kevent ev;
++               int signal_number;
++               struct wl_event_source_signal *_source;
++
++               /* Only one kevent() call needed. */
++               _source = (struct wl_event_source_signal *) source;
++               signal_number = _source->signal_number;
++
++               EV_SET(&ev, signal_number, EVFILT_SIGNAL, EV_DELETE, 0, 0,
++                      source);
++               ret = kevent(loop->event_fd, &ev, 1, NULL, 0, NULL);
++               saved_errno = errno;
++       }
++
++       /* Handle any errors from kevent() calls. */
++       if (ret < 0) {
++               fprintf (stderr,
++                        "error removing event (%i) from kqueue: %s\n",
++                        source->fd, strerror(saved_errno));
++       }
++
++       /* Tidy up the source. */
++       source->fd = -1;
++
++       wl_list_remove(&source->link);
++       wl_list_insert(&loop->destroy_list, &source->link);
++
++       return 0;
++}
++#endif
+ 
+ static void
+ wl_event_loop_process_destroy_list(struct wl_event_loop *loop)
+@@ -350,11 +609,20 @@ wl_event_loop_create(void)
+ 	if (loop == NULL)
+ 		return NULL;
+ 
+-	loop->epoll_fd = wl_os_epoll_create_cloexec();
+-	if (loop->epoll_fd < 0) {
++#ifdef HAVE_SYS_EPOLL_H
++	loop->event_fd = wl_os_epoll_create_cloexec();
++	if (loop->event_fd < 0) {
++		free(loop);
++		return NULL;
++	}
++#elif HAVE_SYS_EVENT_H
++	loop->event_fd = wl_os_kqueue_create_cloexec();
++	if (loop->event_fd < 0) {
+ 		free(loop);
+ 		return NULL;
+ 	}
++#endif
++
+ 	wl_list_init(&loop->check_list);
+ 	wl_list_init(&loop->idle_list);
+ 	wl_list_init(&loop->destroy_list);
+@@ -370,10 +638,11 @@ wl_event_loop_destroy(struct wl_event_lo
+ 	wl_signal_emit(&loop->destroy_signal, loop);
+ 
+ 	wl_event_loop_process_destroy_list(loop);
+-	close(loop->epoll_fd);
++	close(loop->event_fd);
+ 	free(loop);
+ }
+ 
++#ifdef HAVE_SYS_EPOLL_H
+ static int
+ post_dispatch_check(struct wl_event_loop *loop)
+ {
+@@ -388,6 +657,22 @@ post_dispatch_check(struct wl_event_loop
+ 
+ 	return n;
+ }
++#elif HAVE_SYS_EVENT_H
++static int
++post_dispatch_check(struct wl_event_loop *loop)
++{
++       struct kevent ev;
++       struct wl_event_source *source, *next;
++       int n;
++
++       ev.filter = 0;
++       n = 0;
++       wl_list_for_each_safe(source, next, &loop->check_list, link)
++               n += source->interface->dispatch(source, &ev);
++
++       return n;
++}
++#endif
+ 
+ WL_EXPORT void
+ wl_event_loop_dispatch_idle(struct wl_event_loop *loop)
+@@ -402,6 +687,7 @@ wl_event_loop_dispatch_idle(struct wl_ev
+ 	}
+ }
+ 
++#ifdef HAVE_SYS_EPOLL_H
+ WL_EXPORT int
+ wl_event_loop_dispatch(struct wl_event_loop *loop, int timeout)
+ {
+@@ -411,7 +697,7 @@ wl_event_loop_dispatch(struct wl_event_l
+ 
+ 	wl_event_loop_dispatch_idle(loop);
+ 
+-	count = epoll_wait(loop->epoll_fd, ep, ARRAY_LENGTH(ep), timeout);
++	count = epoll_wait(loop->event_fd, ep, ARRAY_LENGTH(ep), timeout);
+ 	if (count < 0)
+ 		return -1;
+ 
+@@ -431,11 +717,48 @@ wl_event_loop_dispatch(struct wl_event_l
+ 
+ 	return 0;
+ }
++#elif HAVE_SYS_EVENT_H
++WL_EXPORT int
++wl_event_loop_dispatch(struct wl_event_loop *loop, int timeout)
++{
++       struct kevent ev[32];
++       struct wl_event_source *source;
++       int i, count, n;
++       struct timespec timeout_spec;
++
++       wl_event_loop_dispatch_idle(loop);
++
++       /* timeout is provided in milliseconds; convert it to a timespec. */
++       timeout_spec.tv_sec = timeout / 1000;
++       timeout_spec.tv_nsec = (timeout % 1000) * 1000000;
++
++       count = kevent(loop->event_fd, NULL, 0, ev, ARRAY_LENGTH(ev),
++                      (timeout != -1) ? &timeout_spec : NULL);
++       if (count < 0)
++               return -1;
++
++       for (i = 0; i < count; i++) {
++               source = ev[i].udata;
++               if (source->fd != -1) {
++                       source->interface->dispatch(source, &ev[i]);
++               }
++       }
++
++       wl_event_loop_process_destroy_list(loop);
++
++       do {
++               n = post_dispatch_check(loop);
++       } while (n > 0);
++
++       return 0;
++}
++#endif
++
+ 
+ WL_EXPORT int
+ wl_event_loop_get_fd(struct wl_event_loop *loop)
+ {
+-	return loop->epoll_fd;
++	return loop->event_fd;
+ }
+ 
+ WL_EXPORT void
+@@ -451,4 +774,3 @@ wl_event_loop_get_destroy_listener(struc
+ {
+ 	return wl_signal_get(&loop->destroy_signal, notify);
+ }
+-

--- a/graphics/wayland/files/patch-src_wayland-os.c
+++ b/graphics/wayland/files/patch-src_wayland-os.c
@@ -1,0 +1,114 @@
+--- src/wayland-os.c.orig	2015-07-06 19:38:51 UTC
++++ src/wayland-os.c
+@@ -25,14 +25,20 @@
+ 
+ #define _GNU_SOURCE
+ 
++#include "../config.h"
++
+ #include <sys/types.h>
+ #include <sys/socket.h>
+ #include <unistd.h>
+ #include <fcntl.h>
+ #include <errno.h>
++#ifdef HAVE_SYS_EPOLL_H
+ #include <sys/epoll.h>
++#endif
++#ifdef HAVE_SYS_EVENT_H
++#include <sys/event.h>
++#endif
+ 
+-#include "../config.h"
+ #include "wayland-os.h"
+ 
+ static int
+@@ -62,26 +68,50 @@ wl_os_socket_cloexec(int domain, int typ
+ {
+ 	int fd;
+ 
++#ifdef SOCK_CLOEXEC
+ 	fd = socket(domain, type | SOCK_CLOEXEC, protocol);
+ 	if (fd >= 0)
+ 		return fd;
+ 	if (errno != EINVAL)
+ 		return -1;
++#endif
+ 
+ 	fd = socket(domain, type, protocol);
+ 	return set_cloexec_or_close(fd);
+ }
+ 
+ int
++wl_os_socketpair_cloexec(int domain, int type, int protocol, int sv[2])
++{
++       int retval;
++
++#ifdef SOCK_CLOEXEC
++       retval = socketpair(domain, type | SOCK_CLOEXEC, protocol, sv);
++       if (retval >= 0)
++               return retval;
++       if (errno != EINVAL)
++               return -1;
++#endif
++
++       retval = socketpair(domain, type, protocol, sv);
++       if (set_cloexec_or_close(sv[0]) < 0 || set_cloexec_or_close(sv[1]) < 0)
++               retval = -1;
++
++       return retval;
++}
++
++int
+ wl_os_dupfd_cloexec(int fd, long minfd)
+ {
+ 	int newfd;
+ 
++#ifdef F_DUPFD_CLOEXEC
+ 	newfd = fcntl(fd, F_DUPFD_CLOEXEC, minfd);
+ 	if (newfd >= 0)
+ 		return newfd;
+ 	if (errno != EINVAL)
+ 		return -1;
++#endif
+ 
+ 	newfd = fcntl(fd, F_DUPFD, minfd);
+ 	return set_cloexec_or_close(newfd);
+@@ -123,15 +153,18 @@ wl_os_recvmsg_cloexec(int sockfd, struct
+ {
+ 	ssize_t len;
+ 
++#ifdef MSG_CMSG_CLOEXEC
+ 	len = recvmsg(sockfd, msg, flags | MSG_CMSG_CLOEXEC);
+ 	if (len >= 0)
+ 		return len;
+ 	if (errno != EINVAL)
+ 		return -1;
++#endif
+ 
+ 	return recvmsg_cloexec_fallback(sockfd, msg, flags);
+ }
+ 
++#ifdef HAVE_SYS_EPOLL_H
+ int
+ wl_os_epoll_create_cloexec(void)
+ {
+@@ -148,6 +181,19 @@ wl_os_epoll_create_cloexec(void)
+ 	fd = epoll_create(1);
+ 	return set_cloexec_or_close(fd);
+ }
++#endif
++
++#ifdef HAVE_SYS_EVENT_H
++int
++wl_os_kqueue_create_cloexec(void)
++{
++	int fd;
++
++	fd = kqueue();
++
++	return set_cloexec_or_close(fd);
++}
++#endif
+ 
+ int
+ wl_os_accept_cloexec(int sockfd, struct sockaddr *addr, socklen_t *addrlen)

--- a/graphics/wayland/files/patch-src_wayland-os.h
+++ b/graphics/wayland/files/patch-src_wayland-os.h
@@ -1,0 +1,28 @@
+--- src/wayland-os.h.orig	2015-07-06 19:38:51 UTC
++++ src/wayland-os.h
+@@ -30,13 +30,25 @@ int
+ wl_os_socket_cloexec(int domain, int type, int protocol);
+ 
+ int
++wl_os_socketpair_cloexec(int domain, int type, int protocol, int sv[2]);
++
++int
+ wl_os_dupfd_cloexec(int fd, long minfd);
+ 
+ ssize_t
+ wl_os_recvmsg_cloexec(int sockfd, struct msghdr *msg, int flags);
+ 
++/* FIXME? not sure if this will work in this header like this ...
++   though seems build only header perhaps? */
++#ifdef HAVE_SYS_EPOLL_H
+ int
+ wl_os_epoll_create_cloexec(void);
++#endif
++
++#ifdef HAVE_SYS_EVENT_H
++int
++wl_os_kqueue_create_cloexec(void);
++#endif
+ 
+ int
+ wl_os_accept_cloexec(int sockfd, struct sockaddr *addr, socklen_t *addrlen);

--- a/graphics/wayland/files/patch-src_wayland-server.c
+++ b/graphics/wayland/files/patch-src_wayland-server.c
@@ -1,0 +1,82 @@
+--- src/wayland-server.c.orig	2016-05-03 00:46:25 UTC
++++ src/wayland-server.c
+@@ -25,6 +25,8 @@
+ 
+ #define _GNU_SOURCE
+ 
++#include "../config.h"
++
+ #include <stdlib.h>
+ #include <stdint.h>
+ #include <stddef.h>
+@@ -43,6 +45,11 @@
+ #include <sys/file.h>
+ #include <sys/stat.h>
+ 
++#ifdef HAVE_SYS_UCRED_H
++#include <sys/types.h>
++#include <sys/ucred.h>
++#endif
++
+ #include "wayland-private.h"
+ #include "wayland-server.h"
+ #include "wayland-server-protocol.h"
+@@ -79,7 +86,13 @@ struct wl_client {
+ 	struct wl_list link;
+ 	struct wl_map objects;
+ 	struct wl_signal destroy_signal;
++#ifdef HAVE_SYS_UCRED_H
++	/* FreeBSD */
++	struct xucred xucred;
++#else
++	/* Linux */
+ 	struct ucred ucred;
++#endif
+ 	int error;
+ };
+ 
+@@ -428,10 +441,20 @@ wl_client_create(struct wl_display *disp
+ 	if (!client->source)
+ 		goto err_client;
+ 
++#if defined(SO_PEERCRED)
++	/* Linux */
+ 	len = sizeof client->ucred;
+ 	if (getsockopt(fd, SOL_SOCKET, SO_PEERCRED,
+ 		       &client->ucred, &len) < 0)
+ 		goto err_source;
++#elif defined(LOCAL_PEERCRED)
++	/* FreeBSD */
++	len = sizeof client->xucred;
++	if (getsockopt(fd, SOL_SOCKET, LOCAL_PEERCRED,
++		       &client->xucred, &len) < 0 ||
++		       client->xucred.cr_version != XUCRED_VERSION)
++		goto err_source;
++#endif
+ 
+ 	client->connection = wl_connection_create(fd);
+ 	if (client->connection == NULL)
+@@ -483,12 +506,23 @@ WL_EXPORT void
+ wl_client_get_credentials(struct wl_client *client,
+ 			  pid_t *pid, uid_t *uid, gid_t *gid)
+ {
++#ifdef HAVE_SYS_UCRED_H
++	/* FreeBSD */
++	if (pid)
++		*pid = 0; /* FIXME: not defined on FreeBSD */
++	if (uid)
++		*uid = client->xucred.cr_uid;
++	if (gid)
++		*gid = client->xucred.cr_gid;
++#else
++	/* Linux */
+ 	if (pid)
+ 		*pid = client->ucred.pid;
+ 	if (uid)
+ 		*uid = client->ucred.uid;
+ 	if (gid)
+ 		*gid = client->ucred.gid;
++#endif
+ }
+ 
+ /** Get the file descriptor for the client

--- a/graphics/wayland/files/patch-src_wayland-shm.c
+++ b/graphics/wayland/files/patch-src_wayland-shm.c
@@ -1,0 +1,147 @@
+--- src/wayland-shm.c.orig	2016-03-09 00:55:02 UTC
++++ src/wayland-shm.c
+@@ -30,6 +30,8 @@
+ 
+ #define _GNU_SOURCE
+ 
++#include "../config.h"
++
+ #include <stdbool.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+@@ -57,6 +59,9 @@ struct wl_shm_pool {
+ 	char *data;
+ 	int32_t size;
+ 	int32_t new_size;
++#ifdef HAVE_SYS_UCRED_H
++	int fd;
++#endif
+ };
+ 
+ struct wl_shm_buffer {
+@@ -74,15 +79,24 @@ struct wl_shm_sigbus_data {
+ 	int fallback_mapping_used;
+ };
+ 
++static void *mremap_compat_maymove(void *, size_t, size_t, int, int, int);
++
+ static void
+ shm_pool_finish_resize(struct wl_shm_pool *pool)
+ {
+ 	void *data;
++	int fd = -1;
+ 
+ 	if (pool->size == pool->new_size)
+ 		return;
+ 
+-	data = mremap(pool->data, pool->size, pool->new_size, MREMAP_MAYMOVE);
++#ifdef HAVE_SYS_UCRED_H
++	fd = pool->fd;
++#endif
++
++	data = mremap_compat_maymove(pool->data, pool->size, pool->new_size,
++				     PROT_READ | PROT_WRITE, MAP_SHARED, fd);
++
+ 	if (data == MAP_FAILED) {
+ 		wl_resource_post_error(pool->resource,
+ 				       WL_SHM_ERROR_INVALID_FD,
+@@ -108,6 +122,10 @@ shm_pool_unref(struct wl_shm_pool *pool,
+ 	if (pool->internal_refcount + pool->external_refcount)
+ 		return;
+ 
++#ifdef HAVE_SYS_UCRED_H
++	close(pool->fd);
++#endif
++
+ 	munmap(pool->data, pool->size);
+ 	free(pool);
+ }
+@@ -221,6 +239,73 @@ shm_pool_destroy(struct wl_client *clien
+ 	wl_resource_destroy(resource);
+ }
+ 
++#ifdef HAVE_MREMAP
++static void *
++mremap_compat_maymove(void *old_address, size_t old_size, size_t new_size,
++		      int old_prot, int old_flags, int old_fd)
++{
++	return mremap(old_address, old_size, new_size, MREMAP_MAYMOVE);
++}
++#else
++static void *
++mremap_compat_maymove(void *old_address, size_t old_size, size_t new_size,
++		      int old_prot, int old_flags, int old_fd)
++{
++	/* FreeBSD doesn't support mremap() yet, so we have to emulate it.
++	 * This assumes MREMAP_MAYMOVE is the only flag in use. */
++	if (new_size == old_size) {
++		return old_address;
++	} else if (new_size < old_size) {
++		/* Shrinking: munmap() the spare region. */
++		munmap(old_address + old_size, new_size - old_size);
++		return old_address;
++	} else {
++		void *ret;
++
++		/* Growing. Try and mmap() the extra region at the end of
++		 * our existing allocation. If that gets mapped in the
++		 * wrong place, fall back to mmap()ing an entirely new
++		 * region of new_size and copying the data across. */
++		ret = mmap(old_address + old_size, new_size - old_size,
++			   old_prot, old_flags, old_fd, 0);
++
++/* FIXME TODO: msync() before munmap()? */
++		if (ret == MAP_FAILED) {
++			/* Total failure! */
++			return ret;
++		} else if (ret == old_address + old_size) {
++			/* Success. */
++			return old_address;
++		} else if (ret != old_address + old_size) {
++			/* Partial failure. Fall back to mapping an
++			 * entirely new region. Unmap the region we
++			 * just mapped first. */
++			munmap(ret, new_size - old_size);
++
++			/* Map an entirely new region. */
++			ret = mmap(NULL, new_size,
++				   old_prot, old_flags, old_fd, 0);
++			if (ret == MAP_FAILED) {
++				/* Total failure! */
++				return ret;
++			}
++
++			/* Copy the old data across. Implicit assumption
++			 * that the old and new regions don't overlap. */
++			memcpy(ret, old_address, old_size);
++
++			/* Unmap the old region. */
++			munmap(old_address, old_size);
++
++			return ret;
++		}
++	}
++
++	/* Unreachable. */
++	return MAP_FAILED;
++}
++#endif
++
+ static void
+ shm_pool_resize(struct wl_client *client, struct wl_resource *resource,
+ 		int32_t size)
+@@ -282,7 +367,14 @@ shm_create_pool(struct wl_client *client
+ 				       "failed mmap fd %d", fd);
+ 		goto err_free;
+ 	}
++
++#ifdef HAVE_SYS_UCRED_H
++	/* We need to keep the FD around on FreeBSD so we can implement
++	 * mremap(). See: mremap_compat_maymove(). */
++	pool->fd = fd;
++#else
+ 	close(fd);
++#endif
+ 
+ 	pool->resource =
+ 		wl_resource_create(client, &wl_shm_pool_interface, 1, id);

--- a/graphics/wayland/files/patch-tests_client-test.c
+++ b/graphics/wayland/files/patch-tests_client-test.c
@@ -1,0 +1,19 @@
+--- tests/client-test.c.orig	2015-07-06 19:38:51 UTC
++++ tests/client-test.c
+@@ -34,6 +34,7 @@
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ 
++#include "wayland-os.h"
+ #include "wayland-private.h"
+ #include "wayland-server.h"
+ #include "test-runner.h"
+@@ -59,7 +60,7 @@ TEST(client_destroy_listener)
+ 	struct client_destroy_listener a, b;
+ 	int s[2];
+ 
+-	assert(socketpair(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0, s) == 0);
++	assert(wl_os_socketpair_cloexec(AF_UNIX, SOCK_STREAM, 0, s) == 0);
+ 	display = wl_display_create();
+ 	assert(display);
+ 	client = wl_client_create(display, s[0]);

--- a/graphics/wayland/files/patch-tests_connection-test.c
+++ b/graphics/wayland/files/patch-tests_connection-test.c
@@ -1,0 +1,29 @@
+--- tests/connection-test.c.orig	2016-02-17 01:13:16 UTC
++++ tests/connection-test.c
+@@ -36,6 +36,7 @@
+ #include <sys/stat.h>
+ #include <poll.h>
+ 
++#include "wayland-os.h"
+ #include "wayland-private.h"
+ #include "test-runner.h"
+ #include "test-compositor.h"
+@@ -47,7 +48,7 @@ setup(int *s)
+ {
+ 	struct wl_connection *connection;
+ 
+-	assert(socketpair(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0, s) == 0);
++	assert(wl_os_socketpair_cloexec(AF_UNIX, SOCK_STREAM, 0, s) == 0);
+ 
+ 	connection = wl_connection_create(s[0]);
+ 	assert(connection);
+@@ -145,8 +146,7 @@ struct marshal_data {
+ static void
+ setup_marshal_data(struct marshal_data *data)
+ {
+-	assert(socketpair(AF_UNIX,
+-			  SOCK_STREAM | SOCK_CLOEXEC, 0, data->s) == 0);
++	assert(wl_os_socketpair_cloexec(AF_UNIX, SOCK_STREAM, 0, data->s) == 0);
+ 	data->read_connection = wl_connection_create(data->s[0]);
+ 	assert(data->read_connection);
+ 	data->write_connection = wl_connection_create(data->s[1]);

--- a/graphics/wayland/files/patch-tests_event-loop-test.c
+++ b/graphics/wayland/files/patch-tests_event-loop-test.c
@@ -1,0 +1,40 @@
+--- tests/event-loop-test.c.orig	2015-07-06 19:38:51 UTC
++++ tests/event-loop-test.c
+@@ -166,10 +166,10 @@ TEST(event_loop_signal)
+ 					  signal_callback, &got_it);
+ 	assert(source);
+ 
+-	wl_event_loop_dispatch(loop, 0);
++	assert(wl_event_loop_dispatch(loop, 0) == 0);
+ 	assert(!got_it);
+-	kill(getpid(), SIGUSR1);
+-	wl_event_loop_dispatch(loop, 0);
++	assert(kill(getpid(), SIGUSR1) == 0);
++	assert(wl_event_loop_dispatch(loop, 0) == 0);
+ 	assert(got_it == 1);
+ 
+ 	wl_event_source_remove(source);
+@@ -233,12 +233,20 @@ TEST(event_loop_timer)
+ 
+ 	source = wl_event_loop_add_timer(loop, timer_callback, &got_it);
+ 	assert(source);
+-	wl_event_source_timer_update(source, 10);
+-	wl_event_loop_dispatch(loop, 0);
++	assert(wl_event_source_timer_update(source, 10) == 0);
++	assert(wl_event_loop_dispatch(loop, 0) == 0);
+ 	assert(!got_it);
+-	wl_event_loop_dispatch(loop, 20);
++	/* FreeBSD has a bug where it converts ms_timeout to ticks; it always adds 1 to the tick count.
++	* Consequently, we need to grossly overcompensate here.
++	* See: http://unix.derkeiler.com/Mailing-Lists/FreeBSD/hackers/2012-07/msg00319.html */
++	assert(wl_event_loop_dispatch(loop, 50) == 0);
+ 	assert(got_it == 1);
+ 
++	/* Check it doesn't fire again. */
++	got_it = 0;
++	assert(wl_event_loop_dispatch(loop, 20) == 0);
++	assert(!got_it);
++
+ 	wl_event_source_remove(source);
+ 	wl_event_loop_destroy(loop);
+ }

--- a/graphics/wayland/files/patch-tests_os-wrappers-test.c
+++ b/graphics/wayland/files/patch-tests_os-wrappers-test.c
@@ -1,0 +1,185 @@
+--- tests/os-wrappers-test.c.orig	2015-07-06 19:38:51 UTC
++++ tests/os-wrappers-test.c
+@@ -26,6 +26,8 @@
+ 
+ #define _GNU_SOURCE
+ 
++#include "../config.h"
++
+ #include <stdlib.h>
+ #include <assert.h>
+ #include <sys/types.h>
+@@ -37,7 +39,13 @@
+ #include <stdarg.h>
+ #include <fcntl.h>
+ #include <stdio.h>
++
++#ifdef HAVE_SYS_EPOLL_H
+ #include <sys/epoll.h>
++#elif HAVE_SYS_EVENT_H
++#include <sys/event.h>
++#include <sys/types.h>
++#endif
+ 
+ #include "wayland-private.h"
+ #include "test-runner.h"
+@@ -54,8 +62,13 @@ static int wrapped_calls_fcntl;
+ static ssize_t (*real_recvmsg)(int, struct msghdr *, int);
+ static int wrapped_calls_recvmsg;
+ 
++#ifdef HAVE_SYS_EPOLL_H
+ static int (*real_epoll_create1)(int);
+ static int wrapped_calls_epoll_create1;
++#elif HAVE_SYS_EVENT_H
++static int (*real_kqueue)(void);
++static int wrapped_calls_kqueue;
++#endif
+ 
+ static void
+ init_fallbacks(int do_fallbacks)
+@@ -64,7 +77,11 @@ init_fallbacks(int do_fallbacks)
+ 	real_socket = dlsym(RTLD_NEXT, "socket");
+ 	real_fcntl = dlsym(RTLD_NEXT, "fcntl");
+ 	real_recvmsg = dlsym(RTLD_NEXT, "recvmsg");
++#ifdef HAVE_SYS_EPOLL_H
+ 	real_epoll_create1 = dlsym(RTLD_NEXT, "epoll_create1");
++#elif HAVE_SYS_EVENT_H
++	real_kqueue = dlsym(RTLD_NEXT, "kqueue");
++#endif
+ }
+ 
+ __attribute__ ((visibility("default"))) int
+@@ -72,10 +89,12 @@ socket(int domain, int type, int protoco
+ {
+ 	wrapped_calls_socket++;
+ 
++#ifdef SOCK_CLOEXEC
+ 	if (fall_back && (type & SOCK_CLOEXEC)) {
+ 		errno = EINVAL;
+ 		return -1;
+ 	}
++#endif
+ 
+ 	return real_socket(domain, type, protocol);
+ }
+@@ -88,10 +107,12 @@ fcntl(int fd, int cmd, ...)
+ 
+ 	wrapped_calls_fcntl++;
+ 
++#ifdef F_DUPFD_CLOEXEC
+ 	if (fall_back && (cmd == F_DUPFD_CLOEXEC)) {
+ 		errno = EINVAL;
+ 		return -1;
+ 	}
++#endif
+ 
+ 	va_start(ap, cmd);
+ 	arg = va_arg(ap, void*);
+@@ -105,14 +126,17 @@ recvmsg(int sockfd, struct msghdr *msg, 
+ {
+ 	wrapped_calls_recvmsg++;
+ 
++#ifdef MSG_CMSG_CLOEXEC
+ 	if (fall_back && (flags & MSG_CMSG_CLOEXEC)) {
+ 		errno = EINVAL;
+ 		return -1;
+ 	}
++#endif
+ 
+ 	return real_recvmsg(sockfd, msg, flags);
+ }
+ 
++#ifdef HAVE_SYS_EPOLL_H
+ __attribute__ ((visibility("default"))) int
+ epoll_create1(int flags)
+ {
+@@ -126,6 +150,15 @@ epoll_create1(int flags)
+ 
+ 	return real_epoll_create1(flags);
+ }
++#elif HAVE_SYS_EVENT_H
++__attribute__ ((visibility("default"))) int
++kqueue(void)
++{
++       wrapped_calls_kqueue++;
++
++       return real_kqueue();
++}
++#endif
+ 
+ static void
+ do_os_wrappers_socket_cloexec(int n)
+@@ -155,12 +188,14 @@ TEST(os_wrappers_socket_cloexec)
+ 	do_os_wrappers_socket_cloexec(0);
+ }
+ 
++#ifdef SOCK_CLOEXEC
+ TEST(os_wrappers_socket_cloexec_fallback)
+ {
+ 	/* forced fallback */
+ 	init_fallbacks(1);
+ 	do_os_wrappers_socket_cloexec(1);
+ }
++#endif
+ 
+ static void
+ do_os_wrappers_dupfd_cloexec(int n)
+@@ -194,11 +229,13 @@ TEST(os_wrappers_dupfd_cloexec)
+ 	do_os_wrappers_dupfd_cloexec(0);
+ }
+ 
++#ifdef F_DUPFD_CLOEXEC
+ TEST(os_wrappers_dupfd_cloexec_fallback)
+ {
+ 	init_fallbacks(1);
+ 	do_os_wrappers_dupfd_cloexec(3);
+ }
++#endif
+ 
+ struct marshal_data {
+ 	struct wl_connection *read_connection;
+@@ -217,8 +254,7 @@ struct marshal_data {
+ static void
+ setup_marshal_data(struct marshal_data *data)
+ {
+-	assert(socketpair(AF_UNIX,
+-			  SOCK_STREAM | SOCK_CLOEXEC, 0, data->s) == 0);
++	assert(wl_os_socketpair_cloexec(AF_UNIX, SOCK_STREAM, 0, data->s) == 0);
+ 
+ 	data->read_connection = wl_connection_create(data->s[0]);
+ 	assert(data->read_connection);
+@@ -327,11 +363,13 @@ TEST(os_wrappers_recvmsg_cloexec)
+ 	do_os_wrappers_recvmsg_cloexec(0);
+ }
+ 
++#ifdef MSG_CMSG_CLOEXEC
+ TEST(os_wrappers_recvmsg_cloexec_fallback)
+ {
+ 	init_fallbacks(1);
+ 	do_os_wrappers_recvmsg_cloexec(1);
+ }
++#endif
+ 
+ static void
+ do_os_wrappers_epoll_create_cloexec(int n)
+@@ -341,12 +379,20 @@ do_os_wrappers_epoll_create_cloexec(int 
+ 
+ 	nr_fds = count_open_fds();
+ 
++#ifdef HAVE_SYS_EPOLL_H
+ 	fd = wl_os_epoll_create_cloexec();
++#elif HAVE_SYS_EVENT_H
++	fd = wl_os_kqueue_create_cloexec();
++#endif
+ 	assert(fd >= 0);
+ 
+ #ifdef EPOLL_CLOEXEC
++#ifdef HAVE_SYS_EPOLL_H
+ 	assert(wrapped_calls_epoll_create1 == n);
+ #else
++	assert(wrapped_calls_kqueue == n);
++#endif
++#else
+ 	printf("No epoll_create1.\n");
+ #endif
+ 

--- a/graphics/wayland/files/patch-tests_queue-test.c
+++ b/graphics/wayland/files/patch-tests_queue-test.c
@@ -1,0 +1,21 @@
+--- tests/queue-test.c.orig	2016-04-29 23:36:09 UTC
++++ tests/queue-test.c
+@@ -23,6 +23,8 @@
+  * SOFTWARE.
+  */
+ 
++#include "../config.h"
++
+ #include <stdlib.h>
+ #include <stdio.h>
+ #include <stdbool.h>
+@@ -30,6 +32,9 @@
+ #include <sys/types.h>
+ #include <sys/wait.h>
+ #include <assert.h>
++#ifdef HAVE_SIGNAL_H
++#include <signal.h>
++#endif
+ 
+ #include "wayland-client.h"
+ #include "wayland-server.h"

--- a/graphics/wayland/files/patch-tests_sanity-test.c
+++ b/graphics/wayland/files/patch-tests_sanity-test.c
@@ -1,0 +1,22 @@
+--- tests/sanity-test.c.orig	2016-02-17 01:13:16 UTC
++++ tests/sanity-test.c
+@@ -92,7 +92,8 @@ FAIL_TEST(sanity_malloc_direct)
+ TEST(disable_leak_checks)
+ {
+ 	volatile void *mem;
+-	assert(leak_check_enabled);
++// XXX FreeBSD disables leak checks...
++//	assert(leak_check_enabled);
+ 	/* normally this should be on the beginning of the test.
+ 	 * Here we need to be sure, that the leak checks are
+ 	 * turned on */
+@@ -171,7 +172,8 @@ sanity_fd_no_leak(void)
+ {
+ 	int fd[2];
+ 
+-	assert(leak_check_enabled);
++// XXX FreeBSD leak checks are disabled
++//	assert(leak_check_enabled);
+ 
+ 	/* leak 2 file descriptors */
+ 	if (pipe(fd) < 0)

--- a/graphics/wayland/files/patch-tests_test-helpers.c
+++ b/graphics/wayland/files/patch-tests_test-helpers.c
@@ -1,0 +1,52 @@
+--- tests/test-helpers.c.orig	2015-07-06 19:38:51 UTC
++++ tests/test-helpers.c
+@@ -23,6 +23,12 @@
+  * SOFTWARE.
+  */
+ 
++#include "../config.h"
++
++#ifdef HAVE_SYS_PARAM_H
++#include <sys/param.h>
++#endif
++
+ #include <assert.h>
+ #include <errno.h>
+ #include <dirent.h>
+@@ -32,6 +38,16 @@
+ 
+ #include "test-runner.h"
+ 
++#ifdef __FreeBSD__
++/* FreeBSD uses fdescfs (which must be mounted using:
++ *    mount -t fdescfs fdescfs /dev/fd
++ * before the test suite can be run). */
++#define OPEN_FDS_DIR "/dev/fd"
++#else
++/* Linux. */
++#define OPEN_FDS_DIR "/proc/self/fd"
++#endif
++
+ int
+ count_open_fds(void)
+ {
+@@ -39,8 +55,8 @@ count_open_fds(void)
+ 	struct dirent *ent;
+ 	int count = 0;
+ 
+-	dir = opendir("/proc/self/fd");
+-	assert(dir && "opening /proc/self/fd failed.");
++	dir = opendir(OPEN_FDS_DIR);
++	assert(dir && "opening " OPEN_FDS_DIR " failed.");
+ 
+ 	errno = 0;
+ 	while ((ent = readdir(dir))) {
+@@ -49,7 +65,7 @@ count_open_fds(void)
+ 			continue;
+ 		count++;
+ 	}
+-	assert(errno == 0 && "reading /proc/self/fd failed.");
++	assert(errno == 0 && "reading " OPEN_FDS_DIR " failed.");
+ 
+ 	closedir(dir);
+ 

--- a/graphics/wayland/files/patch-tests_test-runner.c
+++ b/graphics/wayland/files/patch-tests_test-runner.c
@@ -1,0 +1,170 @@
+--- tests/test-runner.c.orig	2016-05-03 00:46:35 UTC
++++ tests/test-runner.c
+@@ -25,6 +25,12 @@
+ 
+ #define _GNU_SOURCE
+ 
++#include "../config.h"
++
++#ifdef HAVE_SYS_PARAM_H
++#include <sys/param.h>
++#endif
++
+ #include <unistd.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+@@ -37,18 +43,35 @@
+ #include <errno.h>
+ #include <limits.h>
+ #include <sys/ptrace.h>
++#ifdef __linux__
+ #include <sys/prctl.h>
++#endif
+ #ifndef PR_SET_PTRACER
+ # define PR_SET_PTRACER 0x59616d61
+ #endif
++#include <signal.h>
+ 
+ #include "test-runner.h"
+ 
+ static int num_alloc;
++
++extern const struct test __start_test_section, __stop_test_section;
++
++/* This is all disabled for FreeBSD because it gives "can't allocate initial
++ * thread" aborts otherwise. */
++#ifndef __FreeBSD__
+ static void* (*sys_malloc)(size_t);
+ static void (*sys_free)(void*);
+ static void* (*sys_realloc)(void*, size_t);
+ static void* (*sys_calloc)(size_t, size_t);
++#endif
++
++#ifdef __FreeBSD__
++/* XXX review ptrace() usage */
++#define PTRACE_ATTACH PT_ATTACH
++#define PTRACE_CONT PT_CONTINUE
++#define PTRACE_DETACH PT_DETACH
++#endif
+ 
+ /* when set to 1, check if tests are not leaking memory and opened files.
+  * It is turned on by default. It can be turned off by
+@@ -57,7 +80,7 @@ int leak_check_enabled;
+ 
+ /* when this var is set to 0, every call to test_set_timeout() is
+  * suppressed - handy when debugging the test. Can be set by
+- * WAYLAND_TEST_NO_TIMEOUTS environment variable. */
++ * WAYLAND_TESTS_NO_TIMEOUTS evnironment var */
+ static int timeouts_enabled = 1;
+ 
+ /* set to one if the output goes to the terminal */
+@@ -65,6 +88,7 @@ static int is_atty = 0;
+ 
+ extern const struct test __start_test_section, __stop_test_section;
+ 
++#ifndef __FreeBSD__
+ __attribute__ ((visibility("default"))) void *
+ malloc(size_t size)
+ {
+@@ -98,6 +122,7 @@ calloc(size_t nmemb, size_t size)
+ 
+ 	return sys_calloc(nmemb, size);
+ }
++#endif
+ 
+ static const struct test *
+ find_test(const char *name)
+@@ -291,6 +316,8 @@ is_debugger_attached(void)
+ 		return 0;
+ 	}
+ 
++
++// xxx start here
+ 	pid = fork();
+ 	if (pid == -1) {
+ 		perror("fork");
+@@ -311,7 +338,7 @@ is_debugger_attached(void)
+ 			_exit(1);
+ 		if (!waitpid(-1, NULL, 0))
+ 			_exit(1);
+-		ptrace(PTRACE_CONT, NULL, NULL);
++		ptrace(PTRACE_CONT, ppid, NULL, NULL);
+ 		ptrace(PTRACE_DETACH, ppid, NULL, NULL);
+ 		_exit(0);
+ 	} else {
+@@ -345,17 +372,19 @@ int main(int argc, char *argv[])
+ 	const struct test *t;
+ 	pid_t pid;
+ 	int total, pass;
++#ifdef HAVE_WAITID
+ 	siginfo_t info;
++#else
++	int status;
++#endif
+ 
++#ifndef __FreeBSD__
+ 	/* Load system malloc, free, and realloc */
+ 	sys_calloc = dlsym(RTLD_NEXT, "calloc");
+ 	sys_realloc = dlsym(RTLD_NEXT, "realloc");
+ 	sys_malloc = dlsym(RTLD_NEXT, "malloc");
+ 	sys_free = dlsym(RTLD_NEXT, "free");
+ 
+-	if (isatty(fileno(stderr)))
+-		is_atty = 1;
+-
+ 	if (is_debugger_attached()) {
+ 		leak_check_enabled = 0;
+ 		timeouts_enabled = 0;
+@@ -363,6 +392,16 @@ int main(int argc, char *argv[])
+ 		leak_check_enabled = !getenv("WAYLAND_TEST_NO_LEAK_CHECK");
+ 		timeouts_enabled = !getenv("WAYLAND_TEST_NO_TIMEOUTS");
+ 	}
++#else
++	/* Disable leak checking on FreeBSD since we can't override malloc().  */
++	leak_check_enabled = 0;
++	/* XXX review later */
++	timeouts_enabled = 0;
++#endif
++
++	if (isatty(fileno(stderr)))
++		is_atty = 1;
++
+ 
+ 	if (argc == 2 && strcmp(argv[1], "--help") == 0)
+ 		usage(argv[0], EXIT_SUCCESS);
+@@ -394,7 +433,8 @@ int main(int argc, char *argv[])
+ 		if (pid == 0)
+ 			run_test(t); /* never returns */
+ 
+-		if (waitid(P_PID, pid, &info, WEXITED)) {
++#ifdef HAVE_WAITID
++		if (waitid(P_PID, 0, &info, WEXITED)) {
+ 			stderr_set_color(RED);
+ 			fprintf(stderr, "waitid failed: %m\n");
+ 			stderr_reset_color();
+@@ -425,6 +465,25 @@ int main(int argc, char *argv[])
+ 
+ 			break;
+ 		}
++#else
++               if (waitpid(-1, &status, 0) == -1) {
++                       fprintf(stderr, "waitpid failed: %s\n",
++                               strerror(errno));
++                       abort();
++               }
++
++               fprintf(stderr, "test \"%s\":\t", t->name);
++               if (WIFEXITED(status)) {
++                       fprintf(stderr, "exit status %d", WEXITSTATUS(status));
++                       if (WEXITSTATUS(status) == EXIT_SUCCESS)
++                               success = 1;
++               } else if (WIFSIGNALED(status)) {
++                       fprintf(stderr, "signal %d", WTERMSIG(status));
++               }
++#endif
++
++		if (t->must_fail)
++			success = !success;
+ 
+ 		if (success) {
+ 			pass++;

--- a/graphics/wayland/pkg-plist
+++ b/graphics/wayland/pkg-plist
@@ -22,10 +22,10 @@ lib/libwayland-server.a
 lib/libwayland-server.so
 lib/libwayland-server.so.0
 lib/libwayland-server.so.0.1.0
-libdata/pkgconfig/wayland-client.pc
-libdata/pkgconfig/wayland-cursor.pc
-libdata/pkgconfig/wayland-scanner.pc
-libdata/pkgconfig/wayland-server.pc
+lib/pkgconfig/wayland-client.pc
+lib/pkgconfig/wayland-cursor.pc
+lib/pkgconfig/wayland-scanner.pc
+lib/pkgconfig/wayland-server.pc
 share/aclocal/wayland-scanner.m4
 %%DATADIR%%/wayland-scanner.mk
 %%DATADIR%%/wayland.dtd

--- a/x11/libgudev/Makefile
+++ b/x11/libgudev/Makefile
@@ -1,0 +1,22 @@
+# $FreeBSD$
+
+MASTER_SITES= https://download.gnome.org/sources/libgudev/230/
+PORTNAME=	libgudev
+PORTVERSION=	230
+PORTREVISION=	1
+CATEGORIES=	x11
+EXTRACT_SUFX=	.tar.xz
+
+MAINTAINER=	x11@FreeBSD.org
+COMMENT= GObject bindings for libudev.
+
+LICENSE_FILE=	${WRKSRC}/COPYING
+
+USES=		gmake libtool pkgconfig
+GNU_CONFIGURE=	yes
+USE_LDCONFIG=	yes
+CPPFLAGS+=	-I${LOCALBASE}/include
+LIBS+=		-L${LOCALBASE}/lib
+INSTALL_TARGET=	install-strip
+
+.include <bsd.port.mk>

--- a/x11/libgudev/distinfo
+++ b/x11/libgudev/distinfo
@@ -1,0 +1,3 @@
+TIMESTAMP = 1471416504
+SHA256 (libgudev-230.tar.xz) = a2e77faced0c66d7498403adefcc0707105e03db71a2b2abd620025b86347c18
+SIZE (libgudev-230.tar.xz) = 257528

--- a/x11/libgudev/pkg-descr
+++ b/x11/libgudev/pkg-descr
@@ -1,0 +1,3 @@
+libgudev
+
+This library provides GObject bindings for libudev. It was originally part of udev-extras, then udev, then systemd. It's now a project on its own. 

--- a/x11/libgudev/pkg-plist
+++ b/x11/libgudev/pkg-plist
@@ -1,0 +1,13 @@
+include/gudev-1.0/gudev/gudev.h
+include/gudev-1.0/gudev/gudevclient.h
+include/gudev-1.0/gudev/gudevdevice.h
+include/gudev-1.0/gudev/gudevenumerator.h
+include/gudev-1.0/gudev/gudevenums.h
+include/gudev-1.0/gudev/gudevenumtypes.h
+include/gudev-1.0/gudev/gudevtypes.h
+lib/girepository-1.0/GUdev-1.0.typelib
+lib/libgudev-1.0.so
+lib/libgudev-1.0.so.0
+lib/libgudev-1.0.so.0.2.0
+lib/pkgconfig/gudev-1.0.pc
+share/gir-1.0/GUdev-1.0.gir

--- a/x11/libinput/Makefile
+++ b/x11/libinput/Makefile
@@ -1,24 +1,27 @@
 # $FreeBSD$
 
 PORTNAME=	libinput
-PORTVERSION=	1.18.0
+PORTVERSION=	1.4.0
 CATEGORIES=	x11
 
 MAINTAINER=	x11@FreeBSD.org
 COMMENT=	Generic input library
 
 BUILD_DEPENDS=	v4l_compat>=0:${PORTSDIR}/multimedia/v4l_compat
-LIB_DEPENDS=	libevdev.so:${PORTSDIR}/devel/libevdev
+LIB_DEPENDS=	libevdev.so:${PORTSDIR}/devel/libevdev \
+				libepoll-shim.so:${PORTSDIR}/devel/libepoll-shim
 
 USE_GITHUB=	yes
-GH_ACCOUNT=	kwm81
-GH_TAGNAME=	778d6f2
+GH_ACCOUNT=	jiixyj
+GH_TAGNAME=	67c9796
 
 USES=		autoreconf gmake libtool pathfix pkgconfig
 GNU_CONFIGURE=	yes
 PATHFIX_MAKEFILEIN?=	Makefile.am
+
+CONFIGURE_ARGS+= --disable-wacom
+
 CPPFLAGS+=	-I${LOCALBASE}/include
-LDFLAGS+=	-L${LOCALBASE}/lib
 INSTALL_TARGET=	install-strip
 
 .include <bsd.port.mk>

--- a/x11/libinput/distinfo
+++ b/x11/libinput/distinfo
@@ -1,2 +1,3 @@
-SHA256 (kwm81-libinput-1.18.0-778d6f2_GH0.tar.gz) = 71af637cd64eea8300003f46709bd78fd38f3fbd0fab2a39e9835c274cce1a53
-SIZE (kwm81-libinput-1.18.0-778d6f2_GH0.tar.gz) = 636453
+TIMESTAMP = 1471413433
+SHA256 (jiixyj-libinput-1.4.0-67c9796_GH0.tar.gz) = 05a2ad401b4969d80af3495e1e8f7577a185ae2f14e21b3d3194f98f34fac911
+SIZE (jiixyj-libinput-1.4.0-67c9796_GH0.tar.gz) = 731516

--- a/x11/libinput/files/patch-src_Makefile.am
+++ b/x11/libinput/files/patch-src_Makefile.am
@@ -1,0 +1,11 @@
+--- src/Makefile.am.orig	2016-08-17 07:23:05 UTC
++++ src/Makefile.am
+@@ -66,7 +66,7 @@ libfilter_la_CFLAGS = -I$(top_srcdir)/in
+ 			  $(LIBUDEV_CFLAGS)
+ 
+ libinput_la_LDFLAGS = -version-info $(LIBINPUT_LT_VERSION) -shared \
+-		      -Wl,--version-script=$(srcdir)/libinput.sym
++		      -Wl,--version-script=$(srcdir)/libinput.sym -lepoll-shim
+ 
+ pkgconfigdir = $(prefix)/libdata/pkgconfig
+ pkgconfig_DATA = libinput.pc

--- a/x11/libinput/pkg-plist
+++ b/x11/libinput/pkg-plist
@@ -3,7 +3,12 @@ bin/libinput-list-devices
 include/libinput.h
 lib/libinput.so
 lib/libinput.so.10
-lib/libinput.so.10.6.4
+lib/libinput.so.10.9.1
+lib/udev/hwdb.d/90-libinput-model-quirks.hwdb
+lib/udev/libinput-device-group
+lib/udev/libinput-model-quirks
+lib/udev/rules.d/80-libinput-device-groups.rules
+lib/udev/rules.d/90-libinput-model-quirks.rules
 libdata/pkgconfig/libinput.pc
 man/man1/libinput-debug-events.1.gz
 man/man1/libinput-list-devices.1.gz

--- a/x11/libwacom/Makefile
+++ b/x11/libwacom/Makefile
@@ -1,0 +1,27 @@
+#
+# http://downloads.sourceforge.net/project/linuxwacom/libwacom/libwacom-0.22.tar.bz2
+#
+
+
+MASTER_SITES= https://sourceforge.net/projects/linuxwacom/files/libwacom/
+PORTNAME=	libwacom
+PORTVERSION=	0.22
+PORTREVISION=	1
+CATEGORIES=	x11
+EXTRACT_SUFX=	.tar.bz2
+
+MAINTAINER=	x11@FreeBSD.org
+COMMENT=	Add tablet support to libinput, required.
+
+LICENSE_FILE=	${WRKSRC}/COPYING
+
+LIB_DEPENDS=	libgudev-1.0.so:${PORTSDIR}/x11/libgudev
+
+USES=		gmake libtool pkgconfig gnome
+GNU_CONFIGURE=	yes
+USE_LDCONFIG=	yes
+# CPPFLAGS+=	-I${LOCALBASE}/include
+# LIBS+=		-L${LOCALBASE}/lib
+INSTALL_TARGET=	install-strip
+
+.include <bsd.port.mk>

--- a/x11/libwacom/distinfo
+++ b/x11/libwacom/distinfo
@@ -1,0 +1,3 @@
+TIMESTAMP = 1471415542
+SHA256 (libwacom-0.22.tar.bz2) = 97c19c216cbf4a2c54a5fc4f80d5a363bfa732500f0831a345bbc8ab385720c0
+SIZE (libwacom-0.22.tar.bz2) = 462995

--- a/x11/libwacom/pkg-descr
+++ b/x11/libwacom/pkg-descr
@@ -1,0 +1,1 @@
+Libwacom is a new library to help implement Wacom tablet settings. It is intended to be used by client-programs that need model identification. It is already being used by the gnome-settings-daemon and the GNOME 3.4 Control Center Wacom tablet applet. In the future, the xf86-input-wacom driver may use it as well.

--- a/x11/libwacom/pkg-plist
+++ b/x11/libwacom/pkg-plist
@@ -1,0 +1,7 @@
+bin/libwacom-list-local-devices
+include/libwacom-1.0/libwacom/libwacom.h
+lib/libwacom.a
+lib/libwacom.so
+lib/libwacom.so.2
+lib/libwacom.so.2.5.0
+lib/pkgconfig/libwacom.pc

--- a/x11/libxkbcommon/Makefile
+++ b/x11/libxkbcommon/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	libxkbcommon
-PORTVERSION=	0.5.0
+PORTVERSION=	0.6.0
 PORTREVISION=	1
 CATEGORIES=	x11
 MASTER_SITES=	http://xkbcommon.org/download/

--- a/x11/libxkbcommon/distinfo
+++ b/x11/libxkbcommon/distinfo
@@ -1,2 +1,3 @@
-SHA256 (xorg/lib/libxkbcommon-0.5.0.tar.xz) = 90bd7824742b9a6f52a6cf80e2cadd6f5349cf600a358d08260772615b89d19c
-SIZE (xorg/lib/libxkbcommon-0.5.0.tar.xz) = 615504
+TIMESTAMP = 1471396514
+SHA256 (xorg/lib/libxkbcommon-0.6.0.tar.xz) = 69235ec3a13194dea9555d7994bc4548b3ee20070e05a135af5372a958149ef0
+SIZE (xorg/lib/libxkbcommon-0.6.0.tar.xz) = 608700


### PR DESCRIPTION
Bumped wayland to 1.11 (for EFL), wayland-protocols to 1.6, libxkbcommon to 0.6 (for EFL). Changed github source for libinput. Added libinput dependencies libgudev, libwacom and libepoll-shim. Wayland now also uses the libepoll-shim.

New ports
x11/libwacom
x11/libgudev
devel/libepoll-shim
