### PR TITLE
Cairo and gl updates

### DIFF
--- a/graphics/cairo/Makefile
+++ b/graphics/cairo/Makefile
@@ -39,30 +39,36 @@ CONFIGURE_ARGS=	--with-html-dir=${DOCSDIR} \
 		--disable-directfb \
 		--disable-gallium \
 		--disable-wgl \
+		--enable-xlib-xcb \
 		--enable-tee
 
-OPTIONS_DEFINE=	OPENGL GLESV2 EGL XCB GLIB X11
-OPTIONS_DEFAULT=GLESV2 EGL XCB GLIB X11
+OPTIONS_SUB=yes
+OPTIONS_DEFINE=	EGL XCB GLIB X11
+OPTIONS_DEFAULT=GL EGL XCB GLIB X11
 OPTIONS_SLAVE=	${ARCH:tu}
-XCB_DESC=	Enable XCB (X C-language Binding) Support
-GLIB_DESC=	Enable GObject Functions Feature
-GLESV2_DESC=2D/3D rendering support via GLESv2
-EGL_DESC=	Enable EGL functions
-OPTIONS_SUB=	yes
+OPTIONS_SINGLE=	OPENGL
+OPTIONS_SINGLE_OPENGL= NOGL GL GLESV2
+OPENGL_DESC=OpenGL backend
+NOGL_DESC= 	None
 X11_USE=	xorg=x11,xext,xrender
 X11_CONFIGURE_ENABLE=xlib
-OPENGL_USE=	gl=gl xorg=glproto:both,dri2proto:both,dri3proto:both
-OPENGL_CONFIGURE_ENABLE=gl
-OPENGL_IMPLIES=	X11
+GL_USE=	gl=gl xorg=glproto:both,dri2proto:both,dri3proto:both
+GL_DESC=	2D/3D rendering support via OpenGL
+GL_IMPLIES=	X11
+GL_CONFIGURE_ENABLE=gl
 GLESV2_USE=	gl=glesv2
+GLESV2_DESC=2D/3D rendering support via OpenGL ES 2
 GLESV2_CONFIGURE_ENABLE=glesv2
 EGL_USE=	gl=egl
+EGL_DESC=	Enable EGL functions
 EGL_CONFIGURE_ENABLE=egl
 GLIB_USE=	gnome=glib20
+GLIB_DESC=	Enable GObject Functions Feature
 GLIB_CONFIGURE_ENABLE=	gobject
+XCB_USE=	xorg=xcb
+XCB_DESC=	Enable XCB (X C-language Binding) Support
 XCB_BUILD_DEPENDS=	${LOCALBASE}/libdata/pkgconfig/xcb-renderutil.pc:x11/xcb-util-renderutil
 XCB_RUN_DEPENDS=	${LOCALBASE}/libdata/pkgconfig/xcb-renderutil.pc:x11/xcb-util-renderutil
-XCB_USE=	xorg=xcb
 XCB_CONFIGURE_ENABLE=	xcb
 # this has another option --enable-xlib-xcb=auto but it is buggy.
 MIPS_BUILD_DEPENDS=	${LOCALBASE}/include/atomic_ops.h:devel/libatomic_ops

--- a/graphics/cairo/pkg-plist
+++ b/graphics/cairo/pkg-plist
@@ -3,7 +3,7 @@ bin/cairo-trace
 include/cairo/cairo-deprecated.h
 include/cairo/cairo-features.h
 include/cairo/cairo-ft.h
-%%OPENGL%%include/cairo/cairo-gl.h
+%%GL%%include/cairo/cairo-gl.h
 %%GLESV2%%include/cairo/cairo-gl.h
 %%GLIB%%include/cairo/cairo-gobject.h
 include/cairo/cairo-pdf.h
@@ -45,8 +45,8 @@ libdata/pkgconfig/cairo.pc
 libdata/pkgconfig/cairo-fc.pc
 libdata/pkgconfig/cairo-ft.pc
 %%EGL%%libdata/pkgconfig/cairo-egl.pc
-%%OPENGL%%libdata/pkgconfig/cairo-gl.pc
-%%OPENGL%%libdata/pkgconfig/cairo-glx.pc
+%%GL%%libdata/pkgconfig/cairo-gl.pc
+%%GL%%libdata/pkgconfig/cairo-glx.pc
 %%GLESV2%%libdata/pkgconfig/cairo-glesv2.pc
 %%GLIB%%libdata/pkgconfig/cairo-gobject.pc
 libdata/pkgconfig/cairo-pdf.pc

--- a/wayland/weston/Makefile
+++ b/wayland/weston/Makefile
@@ -21,7 +21,7 @@ USE_GL=		egl gbm glesv2
 #TODO: Start a new port based on original code, not Dragonfly port.
 
 #OPTIONS_DEFINE=	CLIENTS
-#OPTIONS_SINGLE=	CAIRO
+# OPTIONS_SINGLE=	CAIRO
 #OPTIONS_SINGLE_CAIRO=	CAIROIMAGE CAIROGL CAIROGLESV2
 #CAIRO_DESC=	Cairo renderer
 #CAIROIMAGE_DESC	= Image
@@ -86,7 +86,7 @@ CONFIGURE_ARGS+=	--disable-fbdev-compositor
 CONFIGURE_ARGS+=	--disable-vaapi-recorder
 CONFIGURE_ARGS+=	--disable-xwayland-test
 
-CONFIGURE_ARGS+=	--with-cairo=glesv2 --with-cairo-glesv2
+CONFIGURE_ARGS+=	--with-cairo=image
 
 CONFIGURE_ENV+= LIBS="-lepoll-shim -lrt -lkbdev -lEGL"
 

--- a/wayland/weston/pkg-plist
+++ b/wayland/weston/pkg-plist
@@ -13,8 +13,6 @@ bin/weston-image
 bin/weston-info
 bin/weston-launch
 bin/weston-multi-resource
-bin/weston-nested
-bin/weston-nested-client
 bin/weston-presentation-shm
 bin/weston-resizor
 bin/weston-scaler

--- a/www/webkit-gtk3/Makefile
+++ b/www/webkit-gtk3/Makefile
@@ -44,21 +44,21 @@ CONFIGURE_ARGS=	--with-gtk=3.0 \
 		--enable-svg-fonts \
 		--enable-geolocation \
 		--enable-webkit2 \
-		--enable-introspection \
-		--enable-egl \
-		--enable-webgl \
-		--enable-gles2 \
-		--enable-wayland-target \
-		--enable-accelerated-compositing \
-		--enable-x11-target
+		--enable-introspection
+#		--enable-egl \
+#		--enable-webgl \
+#		--enable-gles2 \
+#		--enable-wayland-target \
+#		--enable-accelerated-compositing \
+#		--enable-x11-target
 #		--enable-glx \
 
 MAKEFILE=	GNUmakefile
 MAKE_ENV=	XDG_CACHE_HOME=${WRKDIR}
 
 #CONFIGURE_ARGS+=--disable-silent-rules
-#CONFIGURE_ARGS+=--disable-egl \
-#		--disable-gles2
+CONFIGURE_ARGS+=--disable-egl \
+		--disable-gles2
 #		--with-acceleration-backend=opengl # clutter broken?
 # opengl, clutter, none (clutter unsupported)
 


### PR DESCRIPTION
Reverted cario from gles to gl. Changed weston to use cario-image instead of cairo-gl due to rendering bugs in weston clients. Reverted webkit-gtk3 Makefile so it should build properly in poudriere.
