### PR TITLE
Enable Wayland support in SDL2

### DIFF
--- a/devel/sdl20/Makefile
+++ b/devel/sdl20/Makefile
@@ -16,8 +16,7 @@ GNU_CONFIGURE=	yes
 USES=		gmake iconv libtool localbase:ldflags pathfix pkgconfig
 USE_LDCONFIG=	yes
 
-CONFIGURE_ARGS+=	--disable-video-opengles \
-			--disable-altivec \
+CONFIGURE_ARGS+=	--disable-altivec \
 			--disable-arts \
 			--enable-diskaudio \
 			--enable-dummyaudio \
@@ -52,11 +51,13 @@ OPTIONS_DEFINE=		ALSA ASM DLOPEN ESOUND NAS OSS \
 			PULSEAUDIO SNDIO PTHREADS SDL_ATOMIC SDL_AUDIO \
 			SDL_CPUINFO SDL_EVENTS SDL_FILE SDL_HAPTIC \
 			SDL_JOYSTICK SDL_LOADSO SDL_POWER SDL_RENDER \
-			SDL_THREADS SDL_TIMERS SDL_VIDEO VIDEO_OPENGL VIDEO_X11
+			SDL_THREADS SDL_TIMERS SDL_VIDEO VIDEO_OPENGL VIDEO_X11 \
+			VIDEO_OPENGLES_V2 VIDEO_WAYLAND
 OPTIONS_DEFAULT=	ASM DLOPEN OSS PTHREADS SDL_ATOMIC SDL_AUDIO \
 			SDL_CPUINFO SDL_EVENTS SDL_FILE SDL_HAPTIC \
 			SDL_JOYSTICK SDL_LOADSO SDL_POWER SDL_RENDER \
-			SDL_THREADS SDL_TIMERS SDL_VIDEO VIDEO_OPENGL VIDEO_X11
+			SDL_THREADS SDL_TIMERS SDL_VIDEO VIDEO_OPENGL VIDEO_X11 \
+			VIDEO_OPENGLES_V2 VIDEO_WAYLAND
 
 ALSA_DESC=		Audio output via the ALSA audio architecture
 DLOPEN_DESC=		Use dlopen for loading 3rd party libraries
@@ -80,10 +81,12 @@ SDL_TIMERS_DESC=	Enable the SDL Timers subsystem
 SDL_VIDEO_DESC=		Enable the SDL Video subsystem
 VIDEO_OPENGL_DESC=	OpenGL rendering support
 VIDEO_X11_DESC=		X11 rendering support
+VIDEO_OPENGLES_V2_DESC=	OpenGL ES v2 rendering support
+VIDEO_WAYLAND_DESC=		Wayland rendering support
 
 ASM_CONFIGURE_ENABLE=		assembly
 DLOPEN_CONFIGURE_ENABLE=	sdl-dlopen
-PTHREADS_CONFIGURE_ENABLE=	pthreads pthreads-sem
+PTHREADS_CONFIGURE_ENABLE=	pthreads
 SDL_ATOMIC_CONFIGURE_ENABLE=	atomic gcc-atomics
 SDL_AUDIO_CONFIGURE_ENABLE=	audio
 SDL_CPUINFO_CONFIGURE_ENABLE=	cpuinfo
@@ -163,7 +166,7 @@ CONFIGURE_ARGS+=	--disable-sndio --disable-sndio-shared
 IGNORE=	option VIDEO_OPENGL requires SDL_VIDEO
 .endif
 CONFIGURE_ARGS+=	--enable-video-opengl
-USE_GL=			gl
+USE_GL+=			gl
 .else
 CONFIGURE_ARGS+=	--disable-video-opengl
 .endif
@@ -192,6 +195,35 @@ CONFIGURE_ARGS+=	--disable-video-x11 \
 			--disable-video-x11-scrnsaver \
 			--disable-video-x11-xshape \
 			--disable-video-x11-vm
+.endif
+
+.if ${PORT_OPTIONS:MVIDEO_OPENGLES_V2}
+.if !${PORT_OPTIONS:MSDL_VIDEO}
+IGNORE=	option VIDEO_OPENGLES_V2 requires SDL_VIDEO
+.endif
+CONFIGURE_ARGS+=	--enable-video-opengles2
+USE_GL+=			glesv2
+.else
+CONFIGURE_ARGS+=	--disable-video-opengles2
+.endif
+
+.if ${PORT_OPTIONS:MVIDEO_WAYLAND}
+.if !${PORT_OPTIONS:MSDL_VIDEO}
+IGNORE=	option VIDEO_WAYLAND requires SDL_VIDEO
+.endif
+.if !${PORT_OPTIONS:MVIDEO_OPENGLES_V2}
+IGNORE=	option VIDEO_WAYLAND requires VIDEO_OPENGLES_V2
+.endif
+CONFIGURE_ARGS+=	--enable-video-wayland --enable-wayland-shared
+LIB_DEPENDS+=	libxkbcommon.so:x11/libxkbcommon \
+			libwayland-egl.so:graphics/libEGL	\
+			libwayland-cursor.so:wayland/wayland	\
+			libwayland-client.so:wayland/wayland
+BUILD_DEPENDS+=	wayland-protocols>=1.7:wayland/wayland-protocols
+BUILD_DEPENDS+=	wayland-scanner:wayland/wayland
+BUILD_DEPENDS+=	gsed:textproc/gsed
+.else
+CONFIGURE_ARGS+=	--disable-video-wayland --disable-wayland-shared
 .endif
 
 .include <bsd.port.pre.mk>

--- a/devel/sdl20/files/patch-configure
+++ b/devel/sdl20/files/patch-configure
@@ -1,0 +1,42 @@
+--- configure.orig	2016-12-20 13:57:43 UTC
++++ configure
+@@ -23847,9 +23847,9 @@ if test x$video_wayland = xyes; then
+     WAYLAND_CORE_PROTOCOL_SOURCE='$(gen)/wayland-protocol.c'
+     WAYLAND_CORE_PROTOCOL_HEADER='$(gen)/wayland-client-protocol.h'
+     WAYLAND_PROTOCOLS_UNSTABLE_SOURCES=`echo $WAYLAND_PROTOCOLS_UNSTABLE |\
+-        sed 's,[^ ]\+,\\$(gen)/&-protocol.c,g'`
++        gsed 's,[^ ]\+,\\$(gen)/&-protocol.c,g'`
+     WAYLAND_PROTOCOLS_UNSTABLE_HEADERS=`echo $WAYLAND_PROTOCOLS_UNSTABLE |\
+-        sed 's,[^ ]\+,\\$(gen)/&-client-protocol.h,g'`
++        gsed 's,[^ ]\+,\\$(gen)/&-client-protocol.h,g'`
+     GEN_SOURCES="$GEN_SOURCES $WAYLAND_CORE_PROTOCOL_SOURCE $WAYLAND_PROTOCOLS_UNSTABLE_SOURCES"
+     GEN_HEADERS="$GEN_HEADERS $WAYLAND_CORE_PROTOCOL_HEADER $WAYLAND_PROTOCOLS_UNSTABLE_HEADERS"
+ 
+@@ -23864,23 +23864,23 @@ $WAYLAND_CORE_PROTOCOL_HEADER: $WAYLAND_
+ 	\$(RUN_CMD_GEN)\$(WAYLAND_SCANNER) client-header \$< \$@"
+ 
+     WAYLAND_CORE_PROTOCOL_OBJECT="
+-\$(objects)/`echo $WAYLAND_CORE_PROTOCOL_SOURCE | sed 's/\$(gen)\/\(.*\).c$/\1.lo/'`: $WAYLAND_CORE_PROTOCOL_SOURCE
++\$(objects)/`echo $WAYLAND_CORE_PROTOCOL_SOURCE | gsed 's/\$(gen)\/\(.*\).c$/\1.lo/'`: $WAYLAND_CORE_PROTOCOL_SOURCE
+ 	\$(RUN_CMD_CC)\$(LIBTOOL) --tag=CC --mode=compile \$(CC) \$(CFLAGS) \$(EXTRA_CFLAGS) $DEPENDENCY_TRACKING_OPTIONS -c \$< -o \$@"
+ 
+     WAYLAND_PROTOCOLS_CLIENT_HEADER_UNSTABLE_DEPENDS=`for p in $WAYLAND_PROTOCOLS_UNSTABLE;\
+-        do echo ; echo \$p | sed\
++        do echo ; echo \$p | gsed\
+         "s,^\\([a-z\\-]\\+\\)-unstable-\\(v[0-9]\+\\)\$,\\$(gen)/&-client-protocol.h: $WAYLAND_PROTOCOLS_DIR/unstable/\1/&.xml\\\\
+ 	\\$(SHELL) \\$(auxdir)/mkinstalldirs \\$(gen)\\\\
+ 	\\$(RUN_CMD_GEN)\\$(WAYLAND_SCANNER) client-header \\$< \\$@," ; done`
+ 
+     WAYLAND_PROTOCOLS_CODE_UNSTABLE_DEPENDS=`for p in $WAYLAND_PROTOCOLS_UNSTABLE;\
+-        do echo ; echo \$p | sed\
++        do echo ; echo \$p | gsed\
+         "s,^\\([a-z\\-]\\+\\)-unstable-\\(v[0-9]\+\\)\$,\\$(gen)/&-protocol.c: $WAYLAND_PROTOCOLS_DIR/unstable/\1/&.xml\\\\
+ 	\\$(SHELL) \\$(auxdir)/mkinstalldirs \\$(gen)\\\\
+ 	\\$(RUN_CMD_GEN)\\$(WAYLAND_SCANNER) code \\$< \\$@," ; done`
+ 
+     WAYLAND_PROTOCOLS_OBJECTS_UNSTABLE=`for p in $WAYLAND_PROTOCOLS_UNSTABLE;\
+-        do echo ; echo \$p | sed\
++        do echo ; echo \$p | gsed\
+         "s,^\\([a-z\\-]\\+\\)-unstable-\\(v[0-9]\+\\)\$,\\\$(objects)/&-protocol.lo: \\$(gen)/&-protocol.c \\$(gen)/&-client-protocol.h\\\\
+ 	\\$(RUN_CMD_CC)\\$(LIBTOOL) --tag=CC --mode=compile \\$(CC) \\$(CFLAGS) \\$(EXTRA_CFLAGS) $DEPENDENCY_TRACKING_OPTIONS -c \\$< -o \\$@," ; done`
+ 


### PR DESCRIPTION
`games/neverball` works! And `games/stonesoup-sdl` after disabling fullscreen.

Here's a funny transparency effect that happens for some reason :D (the overlays are supposed to be semi-transparent in-game, not to the desktop)
![soup](https://cloud.githubusercontent.com/assets/208340/21354766/6607b10a-c6dc-11e6-9d04-87dc91b6db4e.PNG)